### PR TITLE
Add support for decoding as EJson

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,13 +17,14 @@
     "package.json"
   ],
   "dependencies": {
+    "purescript-affjax-algebra": "^0.1.0",
     "purescript-argonaut": "^0.12.0",
+    "purescript-ejson": "^0.3.0",
     "purescript-free": "^0.9.1",
     "purescript-nonempty": "^0.2.0",
     "purescript-oidc-crypt-utils": "^1.1.0",
     "purescript-pathy": "^0.3.3",
-    "purescript-uri": "^0.3.0",
-    "purescript-affjax-algebra": "^0.1.0"
+    "purescript-uri": "^0.3.0"
   },
   "devDependencies": {
     "purescript-assert": "^0.1.1",

--- a/src/Quasar/Advanced/QuasarAF.purs
+++ b/src/Quasar/Advanced/QuasarAF.purs
@@ -29,7 +29,8 @@ import Data.Functor.Coproduct (Coproduct, left, right)
 import Data.Maybe (Maybe)
 
 import Quasar.Advanced.Auth.Provider as Auth
-import Quasar.Data (QData, JSONMode)
+import Quasar.Data (QData, JSONMode(..))
+import Quasar.Data.Json.Extended (EJson, resultsAsEJson)
 import Quasar.Error (QError(..), lowerQError, printQError)
 import Quasar.FS (Resource)
 import Quasar.Mount (MountConfig)
@@ -52,6 +53,9 @@ serverInfo = left $ ServerInfo id
 readQuery ∷ JSONMode → DirPath → SQL → Vars → Maybe Pagination → QuasarAFP (Either QError JArray)
 readQuery mode path sql vars pagination = left $ ReadQuery mode path sql vars pagination id
 
+readQueryEJson ∷ DirPath → SQL → Vars → Maybe Pagination → QuasarAFP (Either QError (Array EJson))
+readQueryEJson path sql vars pagination = readQuery Precise path sql vars pagination <#> resultsAsEJson
+
 writeQuery ∷ DirPath → FilePath → SQL → Vars → QuasarAFP (Either QError OutputMeta)
 writeQuery path file sql vars = left $ WriteQuery path file sql vars id
 
@@ -66,6 +70,9 @@ dirMetadata path = left $ DirMetadata path id
 
 readFile ∷ JSONMode → FilePath → Maybe Pagination → QuasarAFP (Either QError JArray)
 readFile mode path pagination = left $ ReadFile mode path pagination id
+
+readFileEJson ∷ FilePath → Maybe Pagination → QuasarAFP (Either QError (Array EJson))
+readFileEJson path pagination = readFile Precise path pagination <#> resultsAsEJson
 
 writeFile ∷ FilePath → QData → QuasarAFP (Either QError Unit)
 writeFile path content = left $ WriteFile path content id

--- a/src/Quasar/Data/Json/Extended.purs
+++ b/src/Quasar/Data/Json/Extended.purs
@@ -1,0 +1,24 @@
+module Quasar.Data.Json.Extended
+  ( resultsAsEJson
+  , module Data.Json.Extended
+  ) where
+
+import Prelude
+
+import Control.Monad.Eff.Exception as Exn
+
+import Data.Argonaut (Json, decodeJson)
+import Data.Bifunctor as BF
+import Data.Either (Either)
+import Data.Json.Extended (EJson)
+import Data.Traversable as TR
+
+import Quasar.Error (QError(..))
+
+resultsAsEJson
+  ∷ Either QError (Array Json)
+  → Either QError (Array EJson)
+resultsAsEJson =
+  flip bind $ TR.traverse $
+    decodeJson >>> BF.lmap (Exn.error >>> Error)
+

--- a/src/Quasar/QuasarF.purs
+++ b/src/Quasar/QuasarF.purs
@@ -26,7 +26,8 @@ import Data.Argonaut (JArray)
 import Data.Either (Either)
 import Data.Maybe (Maybe)
 
-import Quasar.Data (QData, JSONMode)
+import Quasar.Data (QData, JSONMode(..))
+import Quasar.Data.Json.Extended (EJson, resultsAsEJson)
 import Quasar.Error (QError(..), lowerQError, printQError)
 import Quasar.FS (Resource)
 import Quasar.Mount (MountConfig)
@@ -76,6 +77,9 @@ serverInfo = ServerInfo id
 readQuery ∷ JSONMode → DirPath → SQL → Vars → Maybe Pagination → QuasarF (Either QError JArray)
 readQuery mode path sql vars pagination = ReadQuery mode path sql vars pagination id
 
+readQueryEJson ∷ DirPath → SQL → Vars → Maybe Pagination → QuasarF (Either QError (Array EJson))
+readQueryEJson path sql vars pagination = readQuery Precise path sql vars pagination <#> resultsAsEJson
+
 writeQuery ∷ DirPath → FilePath → SQL → Vars → QuasarF (Either QError OutputMeta)
 writeQuery path file sql vars = WriteQuery path file sql vars id
 
@@ -90,6 +94,9 @@ dirMetadata path = DirMetadata path id
 
 readFile ∷ JSONMode → FilePath → Maybe Pagination → QuasarF (Either QError JArray)
 readFile mode path pagination = ReadFile mode path pagination id
+
+readFileEJson ∷ FilePath → Maybe Pagination → QuasarF (Either QError (Array EJson))
+readFileEJson path pagination = readFile Precise path pagination <#> resultsAsEJson
 
 writeFile ∷ FilePath → QData → QuasarF (Either QError Unit)
 writeFile path content = WriteFile path content id


### PR DESCRIPTION
This seems to suffice for now.

Later on, when it is supported by Quasar, we'll probably want to add another `JSONMode` for this, and go directly through EJson rather than through the intermediate "precise JSON" encoding. To make that work, it may be necessary to make `JSONMode` into a GADT, using `Leibniz` or something.

https://slamdata.atlassian.net/browse/SD-1573
