### PR TITLE
Parse more error formats from Quasar

### DIFF
--- a/src/Quasar/Error.purs
+++ b/src/Quasar/Error.purs
@@ -18,6 +18,7 @@ module Quasar.Error where
 
 import Prelude
 
+import Data.Argonaut (JObject)
 import Data.Either (Either)
 import Data.Maybe (Maybe(..), maybe)
 import Control.Monad.Eff.Exception (Error, error, message)
@@ -29,7 +30,7 @@ data QError
   | Unauthorized (Maybe UnauthorizedDetails)
   | Forbidden
   | PaymentRequired
-  | ErrorMessage {title :: Maybe String, message :: String}
+  | ErrorMessage {title :: Maybe String, message :: String, raw :: JObject}
   | Error Error
 
 instance showQError ∷ Show QError where

--- a/src/Quasar/Error.purs
+++ b/src/Quasar/Error.purs
@@ -19,7 +19,7 @@ module Quasar.Error where
 import Prelude
 
 import Data.Either (Either)
-import Data.Maybe (Maybe(Just, Nothing))
+import Data.Maybe (Maybe(..), maybe)
 import Control.Monad.Eff.Exception (Error, error, message)
 
 newtype UnauthorizedDetails = UnauthorizedDetails String
@@ -29,6 +29,7 @@ data QError
   | Unauthorized (Maybe UnauthorizedDetails)
   | Forbidden
   | PaymentRequired
+  | ErrorMessage {title :: Maybe String, message :: String}
   | Error Error
 
 instance showQError ∷ Show QError where
@@ -37,6 +38,7 @@ instance showQError ∷ Show QError where
   show (Unauthorized (Just (UnauthorizedDetails details))) = "Unauthorized: " <> details
   show Forbidden = "Forbidden"
   show PaymentRequired = "PaymentRequired"
+  show (ErrorMessage {title, message}) = "(ErrorMesssage {title: " <> show title <> ", message: " <> show message <> "})"
   show (Error err) = "(Error " <> show err <> ")"
 
 printQError ∷ QError → String
@@ -45,6 +47,7 @@ printQError = case _ of
   Unauthorized _ → "Resource is unavailable, authorization is required"
   Forbidden → "Resource is unavailable, the current authorization credentials do not grant access to the resource"
   PaymentRequired → "Resource is unavailable, payment is required to use this feature"
+  ErrorMessage {title, message} → maybe "" (_ <> ": ") title <> message
   Error err → message err
 
 lowerQError ∷ QError → Error

--- a/src/Quasar/QuasarF/Interpreter/Internal.purs
+++ b/src/Quasar/QuasarF/Interpreter/Internal.purs
@@ -169,14 +169,17 @@ hush :: forall a b. Either a b -> Maybe b
 hush = either (const Nothing) Just
 
 -- | Try to parse the known Quasar error formats, to get at a human readable error message
-parseHumanReadableError :: Json.JObject -> Maybe {title :: Maybe String, message :: String}
-parseHumanReadableError json = oneOf (map hush [ json .? "error" <#> {title: Nothing, message: _}
-                                             , do e <- json .? "error"
-                                                  message <- e .? "message"
-                                                  pure {title: Nothing, message}
-                                             , do e <- json .? "error"
-                                                  detail <- e .? "detail"
-                                                  title <- e .?? "status"
-                                                  message <- detail .? "message"
-                                                  pure {title, message}
-                                             ])
+parseHumanReadableError :: Json.JObject -> Maybe {title :: Maybe String, message :: String, raw :: Json.JObject}
+parseHumanReadableError json =
+  oneOf (map hush
+    [ do message <- json .? "error"
+         pure {title: Nothing, message, raw: json}
+    , do e <- json .? "error"
+         message <- e .? "message"
+         pure {title: Nothing, message, raw: json}
+    , do e <- json .? "error"
+         detail <- e .? "detail"
+         title <- e .?? "status"
+         message <- detail .? "message"
+         pure {title, message, raw: json}
+    ])


### PR DESCRIPTION
Also extracts a title and a message field for errors which contain more details.

I tried to produce quasar errors in slamdata and found the formats I'm parsing in this PR. I found that some of them contain both a title as well as a more detailed message, so I added a new `QError` constructor which captures this.

When we get to redesigning the error card having both of these should allow for a nicer UI with a title and details. This will cause all kinds of type errors in slamdata so I thought I'd show what I have and get some critique before continuing.