### PR TITLE
Add property tests for the other mount types

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,6 +30,7 @@
     "purescript-assert": "^3.0.0",
     "purescript-node-process": "^4.0.0",
     "purescript-node-child-process": "^4.0.0",
-    "purescript-node-fs-aff": "^4.0.0"
+    "purescript-node-fs-aff": "^4.0.0",
+    "purescript-generics-rep": "^5.1.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -24,8 +24,7 @@
     "purescript-nonempty": "^4.0.0",
     "purescript-oidc-crypt-utils": "^7.0.0",
     "purescript-pathy": "^4.0.0",
-    "purescript-uri": "^3.0.0",
-    "purescript-strings": "3c844982b2f0c0fc35681d61a6e72de1d58a27bc"
+    "purescript-uri": "^3.0.0"
   },
   "devDependencies": {
     "purescript-assert": "^3.0.0",
@@ -34,8 +33,5 @@
     "purescript-node-fs-aff": "^4.0.0",
     "purescript-generics-rep": "^5.1.0",
     "purescript-quickcheck": "^4.3.0"
-  },
-  "resolutions": {
-    "purescript-strings": "3c844982b2f0c0fc35681d61a6e72de1d58a27bc"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -24,13 +24,18 @@
     "purescript-nonempty": "^4.0.0",
     "purescript-oidc-crypt-utils": "^7.0.0",
     "purescript-pathy": "^4.0.0",
-    "purescript-uri": "^3.0.0"
+    "purescript-uri": "^3.0.0",
+    "purescript-strings": "3c844982b2f0c0fc35681d61a6e72de1d58a27bc"
   },
   "devDependencies": {
     "purescript-assert": "^3.0.0",
     "purescript-node-process": "^4.0.0",
     "purescript-node-child-process": "^4.0.0",
     "purescript-node-fs-aff": "^4.0.0",
-    "purescript-generics-rep": "^5.1.0"
+    "purescript-generics-rep": "^5.1.0",
+    "purescript-quickcheck": "^4.3.0"
+  },
+  "resolutions": {
+    "purescript-strings": "3c844982b2f0c0fc35681d61a6e72de1d58a27bc"
   }
 }

--- a/src/Quasar/Advanced/Paths.purs
+++ b/src/Quasar/Advanced/Paths.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/Advanced/QuasarAF.purs
+++ b/src/Quasar/Advanced/QuasarAF.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/Advanced/QuasarAF/Interpreter/Aff.purs
+++ b/src/Quasar/Advanced/QuasarAF/Interpreter/Aff.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/Advanced/QuasarAF/Interpreter/Affjax.purs
+++ b/src/Quasar/Advanced/QuasarAF/Interpreter/Affjax.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/Advanced/QuasarAF/Interpreter/Config.purs
+++ b/src/Quasar/Advanced/QuasarAF/Interpreter/Config.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/ConfigF.purs
+++ b/src/Quasar/ConfigF.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/Data.purs
+++ b/src/Quasar/Data.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/Data/CSVOptions.purs
+++ b/src/Quasar/Data/CSVOptions.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/Data/JSONMode.purs
+++ b/src/Quasar/Data/JSONMode.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/Error.purs
+++ b/src/Quasar/Error.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/FS.purs
+++ b/src/Quasar/FS.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/FS/DirMetadata.purs
+++ b/src/Quasar/FS/DirMetadata.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/FS/Mount.purs
+++ b/src/Quasar/FS/Mount.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/FS/Resource.purs
+++ b/src/Quasar/FS/Resource.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/Mount.purs
+++ b/src/Quasar/Mount.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/Mount/Common.purs
+++ b/src/Quasar/Mount/Common.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/Mount/Common/Gen.purs
+++ b/src/Quasar/Mount/Common/Gen.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/Mount/Couchbase.purs
+++ b/src/Quasar/Mount/Couchbase.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/Mount/Couchbase/Gen.purs
+++ b/src/Quasar/Mount/Couchbase/Gen.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/Mount/Couchbase/Gen.purs
+++ b/src/Quasar/Mount/Couchbase/Gen.purs
@@ -1,0 +1,38 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+module Quasar.Mount.Couchbase.Gen where
+
+import Prelude
+
+import Control.Monad.Gen (class MonadGen)
+import Control.Monad.Gen as Gen
+import Control.Monad.Rec.Class (class MonadRec)
+import Data.Maybe (Maybe(..))
+import Quasar.Mount.Common.Gen (genAlphaNumericString, genHost)
+import Quasar.Mount.Couchbase as CB
+
+genConfig ∷ ∀ m. MonadGen m ⇒ MonadRec m ⇒ m CB.Config
+genConfig = do
+  host ← genHost
+  withCreds ← Gen.chooseBool
+  case withCreds of
+    true → do
+      user ← Just <$> genAlphaNumericString
+      password ← Just <$> genAlphaNumericString
+      pure { host, user, password }
+    false →
+      pure { host, user: Nothing, password: Nothing }

--- a/src/Quasar/Mount/MarkLogic.purs
+++ b/src/Quasar/Mount/MarkLogic.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/Mount/MarkLogic.purs
+++ b/src/Quasar/Mount/MarkLogic.purs
@@ -54,6 +54,11 @@ data Format
 derive instance eqFormat ∷ Eq Format
 derive instance ordFormat ∷ Ord Format
 
+instance showFormat ∷ Show Format where
+  show = case _ of
+    JSON → "JSON"
+    XML → "XML"
+
 toJSON ∷ Config → Json
 toJSON config =
   let uri = URI.printAbsoluteURI (toURI config)

--- a/src/Quasar/Mount/MarkLogic/Gen.purs
+++ b/src/Quasar/Mount/MarkLogic/Gen.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/Mount/MarkLogic/Gen.purs
+++ b/src/Quasar/Mount/MarkLogic/Gen.purs
@@ -1,0 +1,44 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+module Quasar.Mount.MarkLogic.Gen where
+
+import Prelude
+
+import Control.Monad.Gen (class MonadGen)
+import Control.Monad.Gen as Gen
+import Control.Monad.Gen.Common as GenC
+import Control.Monad.Rec.Class (class MonadRec)
+import Data.Maybe (Maybe(..))
+import Quasar.Mount.Common.Gen (genAlphaNumericString, genHost, genAnyPath)
+import Quasar.Mount.MarkLogic as ML
+
+genFormat ∷ ∀ m. MonadGen m ⇒ m ML.Format
+genFormat = Gen.choose (pure ML.JSON) (pure ML.XML)
+
+genConfig ∷ ∀ m. MonadGen m ⇒ MonadRec m ⇒ m ML.Config
+genConfig = do
+  host ← genHost
+  path ← GenC.genMaybe genAnyPath
+  withCreds ← Gen.chooseBool
+  format ← genFormat
+  case withCreds of
+    true → do
+      user ← Just <$> genAlphaNumericString
+      password ← Just <$> genAlphaNumericString
+      pure { host, path, user, password, format }
+    false →
+      pure { host, path, user: Nothing, password: Nothing, format }

--- a/src/Quasar/Mount/MongoDB.purs
+++ b/src/Quasar/Mount/MongoDB.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/Mount/MongoDB/Gen.purs
+++ b/src/Quasar/Mount/MongoDB/Gen.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/Mount/SparkHDFS.purs
+++ b/src/Quasar/Mount/SparkHDFS.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/Mount/SparkHDFS/Gen.purs
+++ b/src/Quasar/Mount/SparkHDFS/Gen.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/Mount/SparkHDFS/Gen.purs
+++ b/src/Quasar/Mount/SparkHDFS/Gen.purs
@@ -1,0 +1,34 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+module Quasar.Mount.SparkHDFS.Gen where
+
+import Prelude
+
+import Control.Monad.Gen (class MonadGen)
+import Control.Monad.Gen.Common as GenC
+import Control.Monad.Rec.Class (class MonadRec)
+import Data.StrMap.Gen as SMG
+import Quasar.Mount.Common.Gen (genAlphaNumericString, genHost, genAnyPath)
+import Quasar.Mount.SparkHDFS as SHDFS
+
+genConfig ∷ ∀ m. MonadGen m ⇒ MonadRec m ⇒ m SHDFS.Config
+genConfig =
+  { sparkHost: _, hdfsHost: _, path: _, props: _ }
+    <$> genHost
+    <*> genHost
+    <*> GenC.genMaybe genAnyPath
+    <*> SMG.genStrMap genAlphaNumericString (GenC.genMaybe genAlphaNumericString)

--- a/src/Quasar/Mount/SparkHDFS/Gen.purs
+++ b/src/Quasar/Mount/SparkHDFS/Gen.purs
@@ -21,6 +21,7 @@ import Prelude
 import Control.Monad.Gen (class MonadGen)
 import Control.Monad.Gen.Common as GenC
 import Control.Monad.Rec.Class (class MonadRec)
+import Data.Maybe (Maybe(..))
 import Data.StrMap.Gen as SMG
 import Quasar.Mount.Common.Gen (genAlphaNumericString, genHost, genAnyPath)
 import Quasar.Mount.SparkHDFS as SHDFS
@@ -30,5 +31,5 @@ genConfig =
   { sparkHost: _, hdfsHost: _, path: _, props: _ }
     <$> genHost
     <*> genHost
-    <*> GenC.genMaybe genAnyPath
+    <*> (Just <$> genAnyPath)
     <*> SMG.genStrMap genAlphaNumericString (GenC.genMaybe genAlphaNumericString)

--- a/src/Quasar/Mount/SparkLocal.purs
+++ b/src/Quasar/Mount/SparkLocal.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/Mount/SparkLocal/Gen.purs
+++ b/src/Quasar/Mount/SparkLocal/Gen.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/Mount/SparkLocal/Gen.purs
+++ b/src/Quasar/Mount/SparkLocal/Gen.purs
@@ -1,0 +1,25 @@
+{-
+Copyright 2016 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+module Quasar.Mount.SparkLocal.Gen where
+
+import Control.Monad.Gen (class MonadGen)
+import Control.Monad.Rec.Class (class MonadRec)
+import Quasar.Mount.Common.Gen (genDirPath)
+import Quasar.Mount.SparkLocal as SL
+
+genConfig ∷ ∀ m. MonadGen m ⇒ MonadRec m ⇒ m SL.Config
+genConfig = genDirPath

--- a/src/Quasar/Mount/View.purs
+++ b/src/Quasar/Mount/View.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/Paths.purs
+++ b/src/Quasar/Paths.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/QuasarF.purs
+++ b/src/Quasar/QuasarF.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/QuasarF/Interpreter/Aff.purs
+++ b/src/Quasar/QuasarF/Interpreter/Aff.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/QuasarF/Interpreter/Affjax.purs
+++ b/src/Quasar/QuasarF/Interpreter/Affjax.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/QuasarF/Interpreter/Config.purs
+++ b/src/Quasar/QuasarF/Interpreter/Config.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/QuasarF/Interpreter/Internal.purs
+++ b/src/Quasar/QuasarF/Interpreter/Internal.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/Query/OutputMeta.purs
+++ b/src/Quasar/Query/OutputMeta.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/ServerInfo.purs
+++ b/src/Quasar/ServerInfo.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/Quasar/Types.purs
+++ b/src/Quasar/Types.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/src/Test/Main.purs
+++ b/test/src/Test/Main.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/src/Test/Property/Main.purs
+++ b/test/src/Test/Property/Main.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/src/Test/Property/Main.purs
+++ b/test/src/Test/Property/Main.purs
@@ -25,7 +25,7 @@ import Test.Property.Mount.MarkLogic as Quasar.Mount.MarkLogic
 import Test.Property.Mount.MongoDB as Quasar.Mount.MongoDB
 import Test.Property.Mount.SparkHDFS as Quasar.Mount.SparkHDFS
 import Test.Property.Mount.SparkLocal as Quasar.Mount.SparkLocal
-import Test.StrongCheck (SC)
+import Test.QuickCheck (QC)
 
 newtype TestConfig = TestConfig MDB.Config
 
@@ -34,7 +34,7 @@ derive instance eqTestConfig ∷ Eq TestConfig
 instance showTestConfig ∷ Show TestConfig where
   show (TestConfig cfg) = show (MDB.toJSON cfg)
 
-main ∷ ∀ eff. SC eff Unit
+main ∷ ∀ eff. QC eff Unit
 main = do
 
   log "Check Quasar.Mount.Couchbase..."

--- a/test/src/Test/Property/Main.purs
+++ b/test/src/Test/Property/Main.purs
@@ -20,7 +20,11 @@ import Prelude
 
 import Control.Monad.Eff.Console (log)
 import Quasar.Mount.MongoDB as MDB
+import Test.Property.Mount.Couchbase as Quasar.Mount.Couchbase
+import Test.Property.Mount.MarkLogic as Quasar.Mount.MarkLogic
 import Test.Property.Mount.MongoDB as Quasar.Mount.MongoDB
+import Test.Property.Mount.SparkHDFS as Quasar.Mount.SparkHDFS
+import Test.Property.Mount.SparkLocal as Quasar.Mount.SparkLocal
 import Test.StrongCheck (SC)
 
 newtype TestConfig = TestConfig MDB.Config
@@ -32,5 +36,18 @@ instance showTestConfig ∷ Show TestConfig where
 
 main ∷ ∀ eff. SC eff Unit
 main = do
+
+  log "Check Quasar.Mount.Couchbase..."
+  Quasar.Mount.Couchbase.check
+
+  log "Check Quasar.Mount.MarkLogic..."
+  Quasar.Mount.MarkLogic.check
+
   log "Check Quasar.Mount.MongoDB..."
   Quasar.Mount.MongoDB.check
+
+  log "Check Quasar.Mount.SparkHDFS..."
+  Quasar.Mount.SparkHDFS.check
+
+  log "Check Quasar.Mount.SparkLocal..."
+  Quasar.Mount.SparkLocal.check

--- a/test/src/Test/Property/Mount/Couchbase.purs
+++ b/test/src/Test/Property/Mount/Couchbase.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/src/Test/Property/Mount/Couchbase.purs
+++ b/test/src/Test/Property/Mount/Couchbase.purs
@@ -23,8 +23,8 @@ import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
 import Quasar.Mount.Couchbase as CB
 import Quasar.Mount.Couchbase.Gen (genConfig)
-import Test.StrongCheck (SC, Result, quickCheck, (===))
-import Test.StrongCheck.Gen (Gen)
+import Test.QuickCheck (QC, Result, quickCheck, (===))
+import Test.QuickCheck.Gen (Gen)
 
 newtype TestConfig = TestConfig CB.Config
 
@@ -32,7 +32,7 @@ derive instance eqTestConfig ∷ Eq TestConfig
 derive instance genericTestConfig ∷ Generic TestConfig _
 instance showTestConfig ∷ Show TestConfig where show = genericShow
 
-check ∷ ∀ eff. SC eff Unit
+check ∷ ∀ eff. QC eff Unit
 check = quickCheck prop
   where
   prop ∷ Gen Result

--- a/test/src/Test/Property/Mount/Couchbase.purs
+++ b/test/src/Test/Property/Mount/Couchbase.purs
@@ -14,19 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -}
 
-module Test.Property.Mount.MongoDB where
+module Test.Property.Mount.Couchbase where
 
 import Prelude
 
 import Data.Either (Either(..))
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
-import Quasar.Mount.MongoDB as MDB
-import Quasar.Mount.MongoDB.Gen (genConfig)
+import Quasar.Mount.Couchbase as CB
+import Quasar.Mount.Couchbase.Gen (genConfig)
 import Test.StrongCheck (SC, Result, quickCheck, (===))
 import Test.StrongCheck.Gen (Gen)
 
-newtype TestConfig = TestConfig MDB.Config
+newtype TestConfig = TestConfig CB.Config
 
 derive instance eqTestConfig ∷ Eq TestConfig
 derive instance genericTestConfig ∷ Generic TestConfig _
@@ -38,5 +38,5 @@ check = quickCheck prop
   prop ∷ Gen Result
   prop = do
     configIn ← genConfig
-    let configOut = MDB.fromJSON (MDB.toJSON configIn)
+    let configOut = CB.fromJSON (CB.toJSON configIn)
     pure $ Right (TestConfig configIn) === TestConfig <$> configOut

--- a/test/src/Test/Property/Mount/MarkLogic.purs
+++ b/test/src/Test/Property/Mount/MarkLogic.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/src/Test/Property/Mount/MarkLogic.purs
+++ b/test/src/Test/Property/Mount/MarkLogic.purs
@@ -23,8 +23,8 @@ import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
 import Quasar.Mount.MarkLogic as ML
 import Quasar.Mount.MarkLogic.Gen (genConfig)
-import Test.StrongCheck (SC, Result, quickCheck, (===))
-import Test.StrongCheck.Gen (Gen)
+import Test.QuickCheck (QC, Result, quickCheck, (===))
+import Test.QuickCheck.Gen (Gen)
 
 newtype TestConfig = TestConfig ML.Config
 
@@ -32,7 +32,7 @@ derive instance eqTestConfig ∷ Eq TestConfig
 derive instance genericTestConfig ∷ Generic TestConfig _
 instance showTestConfig ∷ Show TestConfig where show = genericShow
 
-check ∷ ∀ eff. SC eff Unit
+check ∷ ∀ eff. QC eff Unit
 check = quickCheck prop
   where
   prop ∷ Gen Result

--- a/test/src/Test/Property/Mount/MarkLogic.purs
+++ b/test/src/Test/Property/Mount/MarkLogic.purs
@@ -14,19 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -}
 
-module Test.Property.Mount.MongoDB where
+module Test.Property.Mount.MarkLogic where
 
 import Prelude
 
 import Data.Either (Either(..))
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
-import Quasar.Mount.MongoDB as MDB
-import Quasar.Mount.MongoDB.Gen (genConfig)
+import Quasar.Mount.MarkLogic as ML
+import Quasar.Mount.MarkLogic.Gen (genConfig)
 import Test.StrongCheck (SC, Result, quickCheck, (===))
 import Test.StrongCheck.Gen (Gen)
 
-newtype TestConfig = TestConfig MDB.Config
+newtype TestConfig = TestConfig ML.Config
 
 derive instance eqTestConfig ∷ Eq TestConfig
 derive instance genericTestConfig ∷ Generic TestConfig _
@@ -38,5 +38,5 @@ check = quickCheck prop
   prop ∷ Gen Result
   prop = do
     configIn ← genConfig
-    let configOut = MDB.fromJSON (MDB.toJSON configIn)
+    let configOut = ML.fromJSON (ML.toJSON configIn)
     pure $ Right (TestConfig configIn) === TestConfig <$> configOut

--- a/test/src/Test/Property/Mount/MongoDB.purs
+++ b/test/src/Test/Property/Mount/MongoDB.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/src/Test/Property/Mount/MongoDB.purs
+++ b/test/src/Test/Property/Mount/MongoDB.purs
@@ -23,8 +23,8 @@ import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
 import Quasar.Mount.MongoDB as MDB
 import Quasar.Mount.MongoDB.Gen (genConfig)
-import Test.StrongCheck (SC, Result, quickCheck, (===))
-import Test.StrongCheck.Gen (Gen)
+import Test.QuickCheck (QC, Result, quickCheck, (===))
+import Test.QuickCheck.Gen (Gen)
 
 newtype TestConfig = TestConfig MDB.Config
 
@@ -32,7 +32,7 @@ derive instance eqTestConfig ∷ Eq TestConfig
 derive instance genericTestConfig ∷ Generic TestConfig _
 instance showTestConfig ∷ Show TestConfig where show = genericShow
 
-check ∷ ∀ eff. SC eff Unit
+check ∷ ∀ eff. QC eff Unit
 check = quickCheck prop
   where
   prop ∷ Gen Result

--- a/test/src/Test/Property/Mount/SparkHDFS.purs
+++ b/test/src/Test/Property/Mount/SparkHDFS.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/src/Test/Property/Mount/SparkHDFS.purs
+++ b/test/src/Test/Property/Mount/SparkHDFS.purs
@@ -23,8 +23,8 @@ import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
 import Quasar.Mount.SparkHDFS as SHDFS
 import Quasar.Mount.SparkHDFS.Gen (genConfig)
-import Test.StrongCheck (SC, Result, quickCheck, (===))
-import Test.StrongCheck.Gen (Gen)
+import Test.QuickCheck (QC, Result, quickCheck, (===))
+import Test.QuickCheck.Gen (Gen)
 
 newtype TestConfig = TestConfig SHDFS.Config
 
@@ -32,7 +32,7 @@ derive instance eqTestConfig ∷ Eq TestConfig
 derive instance genericTestConfig ∷ Generic TestConfig _
 instance showTestConfig ∷ Show TestConfig where show = genericShow
 
-check ∷ ∀ eff. SC eff Unit
+check ∷ ∀ eff. QC eff Unit
 check = quickCheck prop
   where
   prop ∷ Gen Result

--- a/test/src/Test/Property/Mount/SparkHDFS.purs
+++ b/test/src/Test/Property/Mount/SparkHDFS.purs
@@ -14,19 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -}
 
-module Test.Property.Mount.MongoDB where
+module Test.Property.Mount.SparkHDFS where
 
 import Prelude
 
 import Data.Either (Either(..))
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
-import Quasar.Mount.MongoDB as MDB
-import Quasar.Mount.MongoDB.Gen (genConfig)
+import Quasar.Mount.SparkHDFS as SHDFS
+import Quasar.Mount.SparkHDFS.Gen (genConfig)
 import Test.StrongCheck (SC, Result, quickCheck, (===))
 import Test.StrongCheck.Gen (Gen)
 
-newtype TestConfig = TestConfig MDB.Config
+newtype TestConfig = TestConfig SHDFS.Config
 
 derive instance eqTestConfig ∷ Eq TestConfig
 derive instance genericTestConfig ∷ Generic TestConfig _
@@ -38,5 +38,5 @@ check = quickCheck prop
   prop ∷ Gen Result
   prop = do
     configIn ← genConfig
-    let configOut = MDB.fromJSON (MDB.toJSON configIn)
+    let configOut = SHDFS.fromJSON (SHDFS.toJSON configIn)
     pure $ Right (TestConfig configIn) === TestConfig <$> configOut

--- a/test/src/Test/Property/Mount/SparkLocal.purs
+++ b/test/src/Test/Property/Mount/SparkLocal.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/src/Test/Property/Mount/SparkLocal.purs
+++ b/test/src/Test/Property/Mount/SparkLocal.purs
@@ -23,8 +23,8 @@ import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
 import Quasar.Mount.SparkLocal as SL
 import Quasar.Mount.SparkLocal.Gen (genConfig)
-import Test.StrongCheck (SC, Result, quickCheck, (===))
-import Test.StrongCheck.Gen (Gen)
+import Test.QuickCheck (QC, Result, quickCheck, (===))
+import Test.QuickCheck.Gen (Gen)
 
 newtype TestConfig = TestConfig SL.Config
 
@@ -32,7 +32,7 @@ derive instance eqTestConfig ∷ Eq TestConfig
 derive instance genericTestConfig ∷ Generic TestConfig _
 instance showTestConfig ∷ Show TestConfig where show = genericShow
 
-check ∷ ∀ eff. SC eff Unit
+check ∷ ∀ eff. QC eff Unit
 check = quickCheck prop
   where
   prop ∷ Gen Result

--- a/test/src/Test/Property/Mount/SparkLocal.purs
+++ b/test/src/Test/Property/Mount/SparkLocal.purs
@@ -14,19 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -}
 
-module Test.Property.Mount.MongoDB where
+module Test.Property.Mount.SparkLocal where
 
 import Prelude
 
 import Data.Either (Either(..))
 import Data.Generic.Rep (class Generic)
 import Data.Generic.Rep.Show (genericShow)
-import Quasar.Mount.MongoDB as MDB
-import Quasar.Mount.MongoDB.Gen (genConfig)
+import Quasar.Mount.SparkLocal as SL
+import Quasar.Mount.SparkLocal.Gen (genConfig)
 import Test.StrongCheck (SC, Result, quickCheck, (===))
 import Test.StrongCheck.Gen (Gen)
 
-newtype TestConfig = TestConfig MDB.Config
+newtype TestConfig = TestConfig SL.Config
 
 derive instance eqTestConfig ∷ Eq TestConfig
 derive instance genericTestConfig ∷ Generic TestConfig _
@@ -38,5 +38,5 @@ check = quickCheck prop
   prop ∷ Gen Result
   prop = do
     configIn ← genConfig
-    let configOut = MDB.fromJSON (MDB.toJSON configIn)
+    let configOut = SL.fromJSON (SL.toJSON configIn)
     pure $ Right (TestConfig configIn) === TestConfig <$> configOut

--- a/test/src/Util/FS.purs
+++ b/test/src/Util/FS.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/src/Util/Process.purs
+++ b/test/src/Util/Process.purs
@@ -1,5 +1,5 @@
 {-
-Copyright 2016 SlamData, Inc.
+Copyright 2017 SlamData, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Also switched to using `-generics-rep` for deriving `Show`, as using the json codecs to show was sometimes hiding the problems that arose in codec failures.