### PR TITLE
licenseInfo updates

### DIFF
--- a/quasar-versions.json
+++ b/quasar-versions.json
@@ -1,13 +1,13 @@
 { "quasar":
     { "owner": "quasar-analytics"
     , "repo": "quasar"
-    , "tag": "v16.1.9"
+    , "tag": "v16.1.10"
     , "prefix": "quasar-web-assembly"
     }
 , "quasar-advanced":
     { "owner": "slamdata"
     , "repo": "quasar-advanced"
-    , "tag": "v0.7.7"
+    , "tag": "v0.8.0"
     , "prefix": "quasar-advanced-web"
     }
 }

--- a/src/Quasar/Advanced/Types.purs
+++ b/src/Quasar/Advanced/Types.purs
@@ -474,26 +474,32 @@ decodeLicenseStatus =
     "LICENSE_EXPIRED" → Right LicenseExpired
     _ → Left "\"status\" wasn't \"LICENSE_VALID\" or \"licenseExpired\""
 
-type LicenseInfo'
+data LicenseType = Advanced | AdvancedTrial
+
+decodeLicenseType ∷ JString → Either String LicenseType
+decodeLicenseType =
+  case _ of
+    "advancedTrial" → Right AdvancedTrial
+    "advanced" → Right Advanced
+    _ → Left "\"type\" wasn't \"advancedTrial\" or \"advanced\""
+
+type LicenseInfo
   = { expirationDate ∷ String
     , daysRemaining ∷ Int
     , status ∷ LicenseStatus
+    , type ∷ LicenseType
     }
-
-decodeLicenseInfo' ∷ Json → Either String LicenseInfo'
-decodeLicenseInfo' = decodeJson >=> \obj →
-  { expirationDate: _
-  , daysRemaining: _
-  , status: _
-  } <$> obj .? "expiration-date"
-    <*> obj .? "days-remaining"
-    <*> (obj .? "status" >>= decodeLicenseStatus)
-
-type LicenseInfo = { slamdataLicense ∷ LicenseInfo' }
 
 decodeLicenseInfo ∷ Json → Either String LicenseInfo
 decodeLicenseInfo = decodeJson >=> \obj →
-  { slamdataLicense: _ } <$> (obj .? "slamdata-license" >>= decodeLicenseInfo')
+  { expirationDate: _
+  , daysRemaining: _
+  , type: _
+  , status: _
+  } <$> obj .? "expirationDate"
+    <*> obj .? "daysRemaining"
+    <*> (obj .? "type" >>= decodeLicenseType)
+    <*> (obj .? "status" >>= decodeLicenseStatus)
 
 type Licensee =
   { fullName ∷ String

--- a/src/Quasar/Advanced/Types.purs
+++ b/src/Quasar/Advanced/Types.purs
@@ -472,7 +472,7 @@ decodeLicenseStatus =
   case _ of
     "LICENSE_VALID" → Right LicenseValid
     "LICENSE_EXPIRED" → Right LicenseExpired
-    _ → Left "\"status\" wasn't \"LICENSE_VALID\" or \"licenseExpired\""
+    _ → Left "\"status\" wasn't \"LICENSE_VALID\" or \"LICENSE_EXPIRED\""
 
 data LicenseType = Advanced | AdvancedTrial
 


### PR DESCRIPTION
@nicflores and @drostron are working on some quasar-advanced updates to include the type of license, remove a redundant field and camelCase field names. This brings purescript-quasar in line with those updates.