### PR TITLE
Recognise mimir/unknown mounts in the FS

### DIFF
--- a/src/Quasar/FS.purs
+++ b/src/Quasar/FS.purs
@@ -16,10 +16,8 @@ limitations under the License.
 
 module Quasar.FS
   ( module Quasar.FS.DirMetadata
-  , module Quasar.FS.Mount
   , module Quasar.FS.Resource
   ) where
 
 import Quasar.FS.DirMetadata (DirMetadata)
-import Quasar.FS.Mount (Mount(..))
 import Quasar.FS.Resource (Resource(..))

--- a/src/Quasar/FS/Resource.purs
+++ b/src/Quasar/FS/Resource.purs
@@ -19,21 +19,17 @@ module Quasar.FS.Resource where
 import Prelude
 
 import Control.Alt ((<|>))
-
 import Data.Argonaut (Json, decodeJson, (.?))
 import Data.Either (Either(..))
 import Data.Maybe (Maybe)
 import Data.Path.Pathy (DirName, FileName, dir, file, pathName, (</>))
-
-import Quasar.FS.Mount (Mount)
 import Quasar.FS.Mount as Mount
-
 import Quasar.Types (AnyPath, FilePath, DirPath)
 
 data Resource
   = File FilePath
   | Directory DirPath
-  | Mount Mount
+  | Mount Mount.Mount
 
 derive instance eqResource ∷ Eq Resource
 

--- a/src/Quasar/Mount.purs
+++ b/src/Quasar/Mount.purs
@@ -33,6 +33,7 @@ import Quasar.Mount.SparkHDFS as SparkHDFS
 import Quasar.Mount.SparkLocal as SparkLocal
 import Quasar.Mount.Unknown as Unknown
 import Quasar.Mount.View as View
+import Quasar.Mount.Type (MountType(..))
 
 data MountConfig
   = ViewConfig View.Config
@@ -109,6 +110,18 @@ toJSON (SparkFTPConfig config) = SparkFTP.toJSON config
 toJSON (SparkLocalConfig config) = SparkLocal.toJSON config
 toJSON (MimirConfig config) = Mimir.toJSON config
 toJSON (UnknownConfig config) = Unknown.toJSON config
+
+getType ∷ MountConfig → MountType
+getType (ViewConfig _) = View
+getType (ModuleConfig _) = Module
+getType (MongoDBConfig _) = MongoDB
+getType (CouchbaseConfig _) = Couchbase
+getType (MarkLogicConfig _) = MarkLogic
+getType (SparkHDFSConfig _) = SparkHDFS
+getType (SparkFTPConfig _) = SparkFTP
+getType (SparkLocalConfig _) = SparkLocal
+getType (MimirConfig _) = Mimir
+getType (UnknownConfig { mountType }) = Unknown (Just mountType)
 
 _View ∷ Prism' MountConfig View.Config
 _View = prism' ViewConfig case _ of

--- a/src/Quasar/Mount/Type.purs
+++ b/src/Quasar/Mount/Type.purs
@@ -1,0 +1,53 @@
+{-
+Copyright 2017 SlamData, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-}
+
+module Quasar.Mount.Type where
+
+import Prelude
+
+import Data.Generic.Rep (class Generic)
+import Data.Generic.Rep.Show (genericShow)
+import Data.Maybe (Maybe(..))
+
+data MountType
+  = View
+  | Module
+  | MongoDB
+  | Couchbase
+  | MarkLogic
+  | SparkHDFS
+  | SparkFTP
+  | SparkLocal
+  | Mimir
+  | Unknown (Maybe String)
+
+derive instance eqMountType ∷ Eq MountType
+derive instance ordMountType ∷ Ord MountType
+derive instance genericMountType ∷ Generic MountType _
+instance showMountType ∷ Show MountType where show = genericShow
+
+fromName ∷ String → MountType
+fromName = case _ of
+  "view" → View
+  "module" → Module
+  "mongodb" → MongoDB
+  "couchbase" → Couchbase
+  "marklogic" → MarkLogic
+  "spark-hdfs" → SparkHDFS
+  "spark-ftp" → SparkFTP
+  "spark-local" → SparkLocal
+  "mimir" → Mimir
+  other → Unknown (Just other)


### PR DESCRIPTION
This is a bit more of a refactoring than the previous change, but the change here ensures that we won't end up with the FS mount stuff and the mount config sum types out of sync. As well as the FS missing mimir/unknown it was also missing a value for `SparkFTP`. This will be impossible in the future as there is a mapping from config to `MountType` now, which will become partial if only one the config is updated.

Actually, the mapping is only enforced one way, but at least it will be easier not to forget now.