### PR TITLE
Fix connectionURI pretty printer for mongo mounts

### DIFF
--- a/src/Quasar/Mount/MongoDB.purs
+++ b/src/Quasar/Mount/MongoDB.purs
@@ -30,6 +30,7 @@ import Data.Argonaut (Json, decodeJson, jsonEmptyObject, (.?), (:=), (~>))
 import Data.Array as Arr
 import Data.Bifunctor (lmap)
 import Data.Either (Either(..))
+import Data.Foldable (null)
 import Data.Maybe (Maybe(..), maybe)
 import Data.Newtype (class Newtype, unwrap)
 import Data.NonEmpty (NonEmpty(..), oneOf)
@@ -79,7 +80,10 @@ toURI { hosts, auth, props } =
           (combineCredentials <<< _.credentials <<< unwrap <$> auth)
           (oneOf hosts)))
       (_.path <<< unwrap <$> auth))
-    (Just (URI.Query (SM.toUnfoldable props)))
+    (if null props
+      then Nothing
+      else Just (URI.Query (SM.toUnfoldable props)))
+
 
 fromURI ∷ URI.AbsoluteURI → Either String Config
 fromURI (URI.AbsoluteURI scheme (URI.HierarchicalPart auth path) query) = do

--- a/test/src/Test/Unit/Main.purs
+++ b/test/src/Test/Unit/Main.purs
@@ -23,12 +23,15 @@ import Control.Monad.Eff.Console (CONSOLE, log)
 import Data.Argonaut.Parser as JP
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
+import Data.Monoid (mempty)
+import Data.NonEmpty as NE
 import Data.Time.Duration (Seconds(..))
 import Data.Tuple (Tuple(..))
 import Data.URI as URI
 import Data.URI.AbsoluteURI as AbsoluteURI
 import Quasar.Mount as QM
 import Quasar.Mount.Couchbase as CB
+import Quasar.Mount.MongoDB as Mongo
 import Test.Assert (ASSERT, assert')
 import Test.Property.Mount.Couchbase as CBT
 
@@ -64,6 +67,15 @@ main = do
         , docTypeKey: "type"
         , queryTimeout: Just (Seconds (20.0))
         })
+  let mongoURI =
+        AbsoluteURI.print
+          (Mongo.toURI
+            { hosts: NE.singleton (Tuple (URI.NameAddress "localhost") (Just (URI.Port 12345)))
+            , auth: Nothing
+            , props: mempty})
+  if  mongoURI == "mongodb://localhost:12345"
+    then pure unit
+    else fail ("Wrong MongoURI: " <> show mongoURI)
 
 testURIParse
   ∷ ∀ a eff


### PR DESCRIPTION
I looked at the other Mount types, and they don't seem to have this problem, because they either don't use purescript-uri to generate the string, or have at least 1 query parameter required.